### PR TITLE
Add Prettier dependency and configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+
+# Production
+build/
+dist/
+
+# Misc
+.DS_Store
+.idea/*
+.vscode/*
+
+# Environments
+.env
+.env.*
+!.env.example

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+
+# Misc
+.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleAttributePerLine": true,
+  "trailingComma": "es5"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "OSS-book",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "^3.0.2"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
+      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "OSS-book",
+  "name": "book",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "prettier": "^3.0.2"
+  }
+}


### PR DESCRIPTION
- Aggiunto `Prettier` come dipendenza di progetto: in questo modo si assicura consistenza nella versione utilizzata
- Aggiunte configurazioni base per Prettier (`prettierrc` e `prettierignore`)
- Aggiunto script di progetto per eseguire la formattazione (`npm run format`)
- Aggiunto `gitignore` di progetto

>[!IMPORTANT]
Di proposito sono stati solo inseriti i nuovi files in quanto formattazione e stesura del `CONTRIBUTING.md` sono nella PR #33 . Andranno comunque aggiunti nella documentazione i passaggi di installazione dipendenze e run degli scripts, cosa che mi riservo di fare in futuro.

Close #31 

