### PR TITLE
Add first GitHub Pages setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Come contribuire al repository
 
+## Prima installazione
+
+Dopo aver clonato il progetto:
+
+```bash
+npm i
+```
+
+per installare le librerie
+
 ## Formattazione
 
 Tutti i file markdown devono essere formattati con [Prettier](https://prettier.io/) per una miglior leggibilità e per evitare inutili merge conflict se più persone lavorano allo stesso file.
@@ -7,7 +17,7 @@ Tutti i file markdown devono essere formattati con [Prettier](https://prettier.i
 Per formattare da linea di comando tutti i file è necessario avere [Node](https://nodejs.org/it) installato sul proprio computer e lanciare il seguente comando nella cartella del repository:
 
 ```bash
-npx prettier --write "**/*.md"
+npm run format
 ```
 
 Fortunatamente i principali IDE supportano Prettier tramite delle estensioni, di seguito alcuni esempi:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Puoi contribuire al progetto in moltissimi modi.
 Il primo è certamente quello di mettere una stella e di condividere il progetto con chiunque tu conosca.  
 Il secondo è quello di contribuire attivamente al progetto, scrivendo, traducendo, revisionando, disegnando, ecc.  
 Durante la vita del progetto saranno aperte discussioni, sondaggi, pull requests e issue per permettere a chiunque di contribuire in maniera attiva al progetto.  
-Inoltre, puoi diventare un Ambassador del progetto, che ti permetterà di avere un ruolo attivo nella gestione del progetto stesso. Vedi la sezione [Ambassadors](#ambassadors) per maggiori informazioni.
+Inoltre, puoi diventare un Ambassador del progetto, che ti permetterà di avere un ruolo attivo nella gestione del progetto stesso. Vedi la sezione [Ambassadors](#ambassadors) per maggiori informazioni.  
+Maggiori dettagli [qui](CONTRIBUTING.md).
 
 ## Codice di condotta
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+title: Il Libro Open Source

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+## Indice del libro
+
+- [Capitolo di esempio](index.md)
+  - [Paragrafo di esempio](index.md)


### PR DESCRIPTION
- Add `docs` folder for GitHub pages builds
- Add `index.md` as entrypoint for GH Pages (text inside is an example placeholder)
- Add `_config.yml` for `title` and configurations
- Update `CONTRIBUTING.md` with Installation paragraph and updated command for the format script
- Update the Readme with a link to the Contributing page

Close #35 