### PR TITLE
chore: Prettier ora scrive correttamente sui file

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,7 +2,7 @@ colors: true
 pre-commit:
   commands:
     prettier:
-      glob: "*.md"
+      glob: "**/*.md"
       run: npm run format:write {staged_files}
 commit-msg:
   scripts:
@@ -11,6 +11,6 @@ commit-msg:
 pre-push:
   commands:
     format-check:
-      glob: "*.md"
+      glob: "**/*.md"
       run: npm run format:check
       

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "format:check": "npx prettier --check \"**/*.md\"",
-    "format:write": "prettier --write \"**/*.md\""
+    "format:write": "prettier --write"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "format:check": "npx prettier --check \"**/*.md\"",
-    "format:write": "prettier --write"
+    "format:write": "prettier --write \"**/*.md\""
   },
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",


### PR DESCRIPTION
Ho notato durante gli sviluppi in locale che su prettier non era configurato un match dei file, di conseguenza non sapeva dove scrivere.