### PR TITLE
Rimuove il titolo del libro da Introduzione

### DIFF
--- a/docs/it/introduzione.md
+++ b/docs/it/introduzione.md
@@ -1,5 +1,3 @@
-# Il Libro Open Source
-
 ## Benvenuto
 
 Chiunque tu sia, da qualunque posto tu provenga, benvenuto in un viaggio incredibile nel mondo dello sviluppo software.


### PR DESCRIPTION
Il titolo del libro è settato tramite il `_config.yml`.
Questo non solo rende inutile specificarlo per ogni pagina/capitolo, ma lo rende anche "cliccabile" (viene trasformato in un link dinamico alla home page)