### PR TITLE
Aggiunta approvazione contenuti ambassador

### DIFF
--- a/GUIDELINES-CONTENUTI.md
+++ b/GUIDELINES-CONTENUTI.md
@@ -1,0 +1,37 @@
+# Linee guida per l'approvazione e la disapprovazione dei contenuti
+
+Attualmente sono presenti quattro modalità di contribuzione:
+
+- Un membro del team Ambassador può aprire una PR da un _branch_ verso il branch _main_.
+- Un contributor esterno - o Ambassador - può aprire una PR da un proprio _fork_ verso il branch _main_.
+- Un contributor esterno - o Ambassador - può aprire una PR da un proprio _fork_ verso un _branch_ di un Ambassador.
+
+Queste quattro modalità seguiranno dei processi di approvazione contenuti che verranno descritti in questo documento.
+
+## Approvazione di un contenuto verso un branch
+
+Per l'approvazione di un contenuto all'interno di un branch, che sia da parte di un Ambassador che di una figura esterna, sarà sufficiente:
+
+- Approvazione di almeno il 50%+1 degli Ambassador assegnatari. In caso di non raggiungimento del quorum entro 15 giorni dall'apertura della PR, un qualsiasi altro Ambassador potrà fare le veci degli assegnatari non votanti.
+- Superato il tempo massimo di 15 giorni dall'apertura della PR - O 15 giorni dall'ultimo commento o approvazione da parte di un Ambassador -, qualora non venga raggiunto il quorum questa sarà considerata non valida e verrà chiusa da qualsiasi Ambassador avesse modo di farlo e verrà richiesto alla persona che ha aperto la PR di riproporla cercando di creare più coinvolgimento o di modificarne il wording.
+
+Non si ritiene necessaria la presenza del Drafting Group in questa fase in quanto sarà comunque necessario un successivo passaggio prima dell'inserimento in _main_ dei contenuti nel quale loro saranno coinvolti e questo step creerebbe solo eccessivo lavoro per il gruppo.
+
+Si precisa che il conteggio dei tempi di approvazione e raggiungimento del quorum inizia quando la Pull Request (PR) è contrassegnata come _ready for review_, e non più in _draft_.
+
+## Approvazione di un contenuto verso _main_
+
+Per l'approvazione di un contenuto all'interno di main, che sia da parte di un Ambassador che di una figura esterna, sarà sufficiente:
+
+- Approvazione di almeno 5 Ambassador.
+- Approvazione di almeno 1 membro del Drafting Group.
+- Superato il tempo massimo di 15 giorni dall'apertura della PR - O 15 giorni dall'ultimo commento o approvazione da parte di un Ambassador -, questa sarà considerata non valida e verrà chiusa da qualsiasi Ambassador avesse modo di farlo e verrà richiesto alla persona che ha aperto la PR di riproporla cercando di creare più coinvolgimento o di modificarne il wording.
+
+## Disapprovazione di un contenuto
+
+Per esprimere la disapprovazione dei contenuti sarà sufficiente che un membro del team Ambassador commenti la PR indicando in maniera chiara il proprio dissenso (Pollice giù 👎, commento chiaro es. "Non approvo questo contenuto"), al quale deve seguire una spiegazione chiara. Il semplice dissenso non motivato non verrà considerato come valido.
+
+La disapprovazione andrà a ridurre di 1 i numeri per il raggiungimento dei criteri di cui sopra.
+
+Di conseguenza, a titolo di esempio, una PR verso main con 5 voti a favore e approvazione del drafting group ma con una disapprovazione renderà necessaria un'ulteriore approvazione per poter passare.
+Lo stesso vale per il conteggio del Drafting Group, per cui la disapprovazione da parte di uno dei suoi membri richiederà l'approvazione di altri 2 di essi per raggiungere il netto positivo di 1.


### PR DESCRIPTION
Come da Governance Group Meeting del 3 Novembre, espongo un file di linee guida per approvazione e disapprovazione contenuti sul repository del libro.

Closes Il-Libro-Open-Source/governance#27