### PR TITLE
Risoluzione compatibilità Windows con npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "format:check": "npx prettier --check '**/*.md'",
-    "format:write": "prettier --write '**/*.md'",
+    "format:check": "npx prettier --check \"**/*.md\"",
+    "format:write": "prettier --write \"**/*.md\"",
     "format:write:automation": "prettier --write"
   },
   "devDependencies": {


### PR DESCRIPTION
# Descrizione

Gli script non funzionavano in ambiente Windows, per semplicità ho utilizzato la double quote notation per ovviare al problema.

Risolve: #174 