### PR TITLE
ci: bump gh actions versions

### DIFF
--- a/.github/workflows/formatting-validation.yml
+++ b/.github/workflows/formatting-validation.yml
@@ -8,8 +8,8 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Prettier Check


### PR DESCRIPTION
This repo is using outdated Github actions versions.

The newer versions are:
- `actions/checkout@v4` => https://github.com/actions/checkout/releases/tag/v4.0.0
- `actions/setup-node@v4` => https://github.com/actions/setup-node/releases/tag/v4.0.0