### PR TITLE
fix: introduce text auto on gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
# Descrizione

L'immagine `cv-luke.png` risulta cambiata ma non mi permette di effettuare il discard.

# Soluzione

Come descritto nella documentazione di prettier: https://prettier.io/docs/en/options.html#end-of-line
Per permettere alle persone di collaborare su progetti con differenti OS è richiesto che `.gitattributes` contenga 
```* text=auto eol=lf```.

Cito:

> Add * text=auto eol=lf to the repo’s .gitattributes file. You may need to ask Windows users to re-clone your repo after this change to ensure git has not converted LF to CRLF on checkout.

# OS da provare

- [x] macOS
- [ ] Ubuntu
- [ ] Windows