### PR TITLE
Theme switcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
+    google-protobuf (3.25.2-arm64-darwin)
     google-protobuf (3.25.2-x86_64-darwin)
     google-protobuf (3.25.2-x86_64-linux)
     http_parser.rb (0.8.0)
@@ -64,16 +65,16 @@ GEM
     rexml (3.2.6)
     rouge (4.2.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.70.0-x86_64-darwin)
-      google-protobuf (~> 3.25)
-    sass-embedded (1.70.0-x86_64-linux-gnu)
-      google-protobuf (~> 3.25)
+    sass-embedded (1.63.6)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 
@@ -81,4 +82,4 @@ DEPENDENCIES
   just-the-docs
 
 BUNDLED WITH
-   2.3.26
+   2.4.19

--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -32,18 +32,23 @@
 </style>
 <script>
     const toggleDarkMode = document.querySelector('#theme-switcher');
+    const hasLocalStorage = typeof localStorage !== 'undefined'
 
     function switchTo(theme) {
         if (theme === 'dark') {
             jtd.setTheme('dark');
             toggleDarkMode.classList.add('dark');
             toggleDarkMode.classList.remove('light');
-            localStorage.setItem('prefers-color-scheme', 'dark');
+            if (hasLocalStorage) {
+                localStorage.setItem('prefers-color-scheme', 'dark');
+            }
         } else if (theme === 'light') {
             jtd.setTheme('light');
             toggleDarkMode.classList.add('light');
             toggleDarkMode.classList.remove('dark');
-            localStorage.setItem('prefers-color-scheme', 'light');
+            if (hasLocalStorage) {
+                localStorage.setItem('prefers-color-scheme', 'light');
+            }
         }
     }
 
@@ -51,7 +56,7 @@
     var lightAsPrefersColorSchema = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
 
     var savedColorSchema = null;
-    if (typeof localStorage !== 'undefined') {
+    if (hasLocalStorage) {
         savedColorSchema = localStorage.getItem('prefers-color-scheme');
     }
 

--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -1,0 +1,79 @@
+<div id="theme-switcher">
+    <svg id="theme-switcher-moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30"
+        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+
+    <svg id="theme-switcher-sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="30" height="30"
+        fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="12" cy="12" r="5"></circle>
+        <line x1="12" y1="1" x2="12" y2="3"></line>
+        <line x1="12" y1="21" x2="12" y2="23"></line>
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+        <line x1="1" y1="12" x2="3" y2="12"></line>
+        <line x1="21" y1="12" x2="23" y2="12"></line>
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+</div>
+<style>
+    #theme-switcher {
+        align-self: center;
+    }
+
+    #theme-switcher.light #theme-switcher-sun {
+        display: none;
+    }
+
+    #theme-switcher.dark #theme-switcher-moon {
+        display: none;
+    }
+</style>
+<script>
+    const toggleDarkMode = document.querySelector('#theme-switcher');
+
+    function switchTo(theme) {
+        if (theme === 'dark') {
+            jtd.setTheme('dark');
+            toggleDarkMode.classList.add('dark');
+            toggleDarkMode.classList.remove('light');
+            localStorage.setItem('prefers-color-scheme', 'dark');
+        } else if (theme === 'light') {
+            jtd.setTheme('light');
+            toggleDarkMode.classList.add('light');
+            toggleDarkMode.classList.remove('dark');
+            localStorage.setItem('prefers-color-scheme', 'light');
+        }
+    }
+
+    var darkAsPrefersColorSchema = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var lightAsPrefersColorSchema = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+
+    var savedColorSchema = null;
+    if (typeof localStorage !== 'undefined') {
+        savedColorSchema = localStorage.getItem('prefers-color-scheme');
+    }
+
+    if (savedColorSchema) {
+        if (savedColorSchema === 'dark') {
+            switchTo('dark')
+        } else {
+            switchTo('light')
+        }
+    } else {
+        if (darkAsPrefersColorSchema) {
+            switchTo('dark')
+        } else {
+            switchTo('light')
+        }
+    }
+
+    jtd.addEvent(toggleDarkMode, 'click', function () {
+        if (jtd.getTheme() === 'dark') {
+            switchTo('light')
+        } else {
+            switchTo('dark')
+        }
+    });
+</script>

--- a/_includes/header_custom.html
+++ b/_includes/header_custom.html
@@ -32,7 +32,7 @@
 </style>
 <script>
     const toggleDarkMode = document.querySelector('#theme-switcher');
-    const hasLocalStorage = typeof localStorage !== 'undefined'
+    const hasLocalStorage = typeof localStorage !== 'undefined';
 
     function switchTo(theme) {
         if (theme === 'dark') {


### PR DESCRIPTION
Implementazione del theme switcher a fianco della search.
Comportamento:
- al primo caricamento usa il tema di sistema: se è dark configura il sito con dark, altrimenti con light. Su browser che non supporta il `window.matchMedia` usa il tema light.
- a click viene effettuata l'inversione di tema
- il sito si ricorda il tema scelto salvando la preferenza nel localStorage
- funzione solo se hai il JS attivo sul browser

I colori del tema dark sono quelli di default di just-the-docs.
Se il localStorage non è definito, non viene salvata la preferenza.
Le icone sono generate da chatGPT.

Riporto gli screenshot qui sotto:
<img width="1110" alt="Screenshot 2024-09-17 at 10 23 38" src="https://github.com/user-attachments/assets/b74491c3-8ced-4aec-b998-e5aca350620e">
<img width="1111" alt="Screenshot 2024-09-17 at 10 23 58" src="https://github.com/user-attachments/assets/167ce793-0a7b-4ea9-a0f0-161fdcad5ff6">
