### PR TITLE
Fix typo on "Documentazione" chapter

### DIFF
--- a/docs/it/cultura/documentazione.md
+++ b/docs/it/cultura/documentazione.md
@@ -200,7 +200,7 @@ Questi, naturalmente, sono solo alcuni possibili esempi di standardizzazione del
 
 Per esempio, se usi Confluence, un'idea potrebbe essere quella di crearti uno spazio in cui scrivi i template prer la tua documentazione.
 
-> **NOTA**: Gli esempi riportati, tradotti in italiano e modificati per una audience adatta agli dviluppatori, sono stati ripresi dal libro [Crafting Docs for Success: An End-to-End Approach to Developer Documentation](https://link.springer.com/book/10.1007/978-1-4842-9594-6)
+> **NOTA**: Gli esempi riportati, tradotti in italiano e modificati per una audience adatta agli sviluppatori, sono stati ripresi dal libro [Crafting Docs for Success: An End-to-End Approach to Developer Documentation](https://link.springer.com/book/10.1007/978-1-4842-9594-6)
 
 ## La collaborazione coi technical writers
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "book",
+  "name": "il-libro-open-source",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This pull request includes a typo fix in the Italian documentation file `docs/it/cultura/documentazione.md`. The word "dviluppatori" was corrected to "sviluppatori" in a note referencing a book.